### PR TITLE
De 876 target bigquery make pr to generate safe column values

### DIFF
--- a/target_bigquery/sinks.py
+++ b/target_bigquery/sinks.py
@@ -187,7 +187,7 @@ class BaseBigQuerySink(BatchSink):
             )
             self._table_ref = self._client.create_table(table, exists_ok=True)
             if self.config.get("generate_view"):
-                ddl = SchemaTranslator(self.schema).make_view_stmt(self._table)
+                ddl = SchemaTranslator(schema = self.schema, fix_columns= self.config["fix_columns"]).make_view_stmt(self._table)
                 self._client.query(ddl).result()
 
     @property
@@ -232,7 +232,7 @@ class BaseBigQuerySinkDenormalized(BaseBigQuerySink):
         key_properties: Optional[List[str]],
     ) -> None:
         super().__init__(target, stream_name, schema, key_properties)
-        self._bq_schema = SchemaTranslator(schema).translated_schema
+        self._bq_schema = SchemaTranslator(schema = self.schema, fix_columns= self.config["fix_columns"]).translated_schema
 
     @retry(
         retry=retry_if_exception_type(ConnectionError),

--- a/target_bigquery/sinks.py
+++ b/target_bigquery/sinks.py
@@ -187,7 +187,7 @@ class BaseBigQuerySink(BatchSink):
             )
             self._table_ref = self._client.create_table(table, exists_ok=True)
             if self.config.get("generate_view"):
-                ddl = SchemaTranslator(schema = self.schema, fix_columns= self.config["fix_columns"]).make_view_stmt(self._table)
+                ddl = SchemaTranslator(schema = self.schema, fix_columns= self.config.get("fix_columns")).make_view_stmt(self._table)
                 self._client.query(ddl).result()
 
     @property
@@ -232,7 +232,7 @@ class BaseBigQuerySinkDenormalized(BaseBigQuerySink):
         key_properties: Optional[List[str]],
     ) -> None:
         super().__init__(target, stream_name, schema, key_properties)
-        self._bq_schema = SchemaTranslator(schema = self.schema, fix_columns= self.config["fix_columns"]).translated_schema
+        self._bq_schema = SchemaTranslator(schema = self.schema, fix_columns= self.config.get("fix_columns")).translated_schema
 
     @retry(
         retry=retry_if_exception_type(ConnectionError),

--- a/target_bigquery/sinks.py
+++ b/target_bigquery/sinks.py
@@ -187,6 +187,7 @@ class BaseBigQuerySink(BatchSink):
             )
             self._table_ref = self._client.create_table(table, exists_ok=True)
             if self.config.get("generate_view"):
+                self.logger.info(self.config.get("fix_columns"))
                 ddl = SchemaTranslator(schema = self.schema, fix_columns= self.config.get("fix_columns")).make_view_stmt(self._table)
                 self._client.query(ddl).result()
 

--- a/target_bigquery/sinks.py
+++ b/target_bigquery/sinks.py
@@ -187,7 +187,6 @@ class BaseBigQuerySink(BatchSink):
             )
             self._table_ref = self._client.create_table(table, exists_ok=True)
             if self.config.get("generate_view"):
-                self.logger.info(self.config.get("fix_columns"))
                 ddl = SchemaTranslator(schema = self.schema, fix_columns= self.config.get("fix_columns")).make_view_stmt(self._table)
                 self._client.query(ddl).result()
 

--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -133,7 +133,12 @@ class TargetBigQuery(Target):
                 )
             ),
             description="Whether to apply parsing to columns. Can be customized",
-            required=False
+            required=False,
+            default = {
+                "lower": False,
+                "quotes": False,
+                "add_underscore_when_invalid": False
+            }
         ),
     ).to_dict()
 

--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -133,7 +133,6 @@ class TargetBigQuery(Target):
                 )
             ),
             description="Whether to apply parsing to columns. Can be customized",
-            default=False,
         ),
     ).to_dict()
 

--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -133,6 +133,7 @@ class TargetBigQuery(Target):
                 )
             ),
             description="Whether to apply parsing to columns. Can be customized",
+            required=False
         ),
     ).to_dict()
 

--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -113,6 +113,28 @@ class TargetBigQuery(Target):
             "for GCS based ingestion. Only used if method is gcs_stage.",
             default=250,
         ),
+        th.Property(
+            "fix_columns",
+            th.ObjectType(
+                th.Property(
+                    "lower",
+                    th.BooleanType,
+                    default=False
+                ),
+                th.Property(
+                    "quotes",
+                    th.BooleanType,
+                    default=False
+                ),
+                th.Property(
+                    "add_underscore_when_invalid",
+                    th.BooleanType,
+                    default=False
+                )
+            ),
+            description="Whether to apply parsing to columns. Can be customized",
+            default=False,
+        ),
     ).to_dict()
 
     @property

--- a/target_bigquery/utils.py
+++ b/target_bigquery/utils.py
@@ -55,11 +55,13 @@ def safe_column_name(name: str, fix_columns: dict) -> str:
 class SchemaTranslator:
     def __init__(self, schema, fix_columns):
         self.schema = schema
-        self.fix_columns = {
-            "quotes": False,
-            "lower": False,
-            "add_underscore_when_invalid": True
-        }
+        # self.fix_columns = {
+        #     "quotes": False,
+        #     "lower": False,
+        #     "add_underscore_when_invalid": True
+        # }
+        self.fix_columns = fix_columns
+        self.logger.info(fix_columns)
         self.translated_schema = [
             self._jsonschema_prop_to_bq_column(name, contents, self.fix_columns)
             for name, contents in self.schema.get("properties", {}).items()

--- a/target_bigquery/utils.py
+++ b/target_bigquery/utils.py
@@ -55,12 +55,8 @@ def safe_column_name(name: str, fix_columns: dict) -> str:
 class SchemaTranslator:
     def __init__(self, schema, fix_columns):
         self.schema = schema
-        # self.fix_columns = {
-        #     "quotes": False,
-        #     "lower": False,
-        #     "add_underscore_when_invalid": True
-        # }
         self.fix_columns = fix_columns
+
         self.translated_schema = [
             self._jsonschema_prop_to_bq_column(name, contents, self.fix_columns)
             for name, contents in self.schema.get("properties", {}).items()

--- a/target_bigquery/utils.py
+++ b/target_bigquery/utils.py
@@ -55,6 +55,7 @@ def safe_column_name(name: str, fix_columns: dict) -> str:
 class SchemaTranslator:
     def __init__(self, schema, fix_columns):
         self.schema = schema
+        self.fix_columns = fix_columns
         self.translated_schema = [
             self._jsonschema_prop_to_bq_column(name, contents, fix_columns)
             for name, contents in self.schema.get("properties", {}).items()

--- a/target_bigquery/utils.py
+++ b/target_bigquery/utils.py
@@ -31,34 +31,41 @@ def bigquery_type(property_type: List[str], property_format: str) -> str:
 # business logic employed outside user control which makes them reliant
 # on other load methods performing the same transformation. With that said,
 # it may be necessary when columns would otherwise break a load job.
-def safe_column_name(name: str, quotes: bool = False) -> str:
+def safe_column_name(name: str, fix_columns: dict) -> str:
+    quotes = fix_columns["quotes"]
+    lower = fix_columns["lower"]
+    add_underscore_when_invalid = fix_columns["add_underscore_when_invalid"]
+
     name = name.replace("`", "")
     pattern = "[^a-zA-Z0-9_]"
     name = re.sub(pattern, "_", name)
+
     if quotes:
-        return "`{}`".format(name).lower()
-    # return "{}".format(name).lower()
-    if name[0].isdigit():
-        return "_{}".format(name)
-    return "{}".format(name)
+        name = "`{}`".format(name)
+    if lower:
+        name = "{}".format(name).lower()
+    if add_underscore_when_invalid:
+        if name[0].isdigit():
+            name = "_{}".format(name)
+    return name
 
 
 # This class translates a JSON schema into a BigQuery schema.
 # It also uses the translated schema to generate a CREATE VIEW statement.
 class SchemaTranslator:
-    def __init__(self, schema):
+    def __init__(self, schema, fix_columns):
         self.schema = schema
         self.translated_schema = [
-            self._jsonschema_prop_to_bq_column(name, contents)
+            self._jsonschema_prop_to_bq_column(name, contents, fix_columns)
             for name, contents in self.schema.get("properties", {}).items()
         ]
 
     def _jsonschema_prop_to_bq_column(
-        self, name: str, schema_property: dict
+        self, name: str, schema_property: dict, fix_columns: dict
     ) -> SchemaField:
         # Don't munge names, much more portable the less business logic we apply
         # safe_name = safe_column_name(name, quotes=False)  <- this mutates the name
-        safe_name = safe_column_name(name, quotes=False)
+        safe_name = safe_column_name(name, fix_columns=fix_columns)
         # safe_name = name
 
         if "anyOf" in schema_property and len(schema_property["anyOf"]) > 0:

--- a/target_bigquery/utils.py
+++ b/target_bigquery/utils.py
@@ -55,7 +55,11 @@ def safe_column_name(name: str, fix_columns: dict) -> str:
 class SchemaTranslator:
     def __init__(self, schema, fix_columns):
         self.schema = schema
-        self.fix_columns = fix_columns
+        self.fix_columns = {
+            "quotes": False,
+            "lower": False,
+            "add_underscore_when_invalid": True
+        }
         self.translated_schema = [
             self._jsonschema_prop_to_bq_column(name, contents, fix_columns)
             for name, contents in self.schema.get("properties", {}).items()

--- a/target_bigquery/utils.py
+++ b/target_bigquery/utils.py
@@ -54,8 +54,9 @@ class SchemaTranslator:
         self, name: str, schema_property: dict
     ) -> SchemaField:
         # Don't munge names, much more portable the less business logic we apply
-        # safe_name = safe_column_name(name, quotes=False) <- this mutates the name
-        safe_name = name
+        # safe_name = safe_column_name(name, quotes=False)  <- this mutates the name
+        safe_name = safe_column_name(name, quotes=False)
+        # safe_name = name
 
         if "anyOf" in schema_property and len(schema_property["anyOf"]) > 0:
             # I have only seen this used in the wild with tap-salesforce, which
@@ -452,8 +453,8 @@ def test_convoluted_schema():
 
     TARGET = dedent(
         """
-    CREATE OR REPLACE VIEW my.neighbor.totoro_view AS 
-    SELECT 
+    CREATE OR REPLACE VIEW my.neighbor.totoro_view AS
+    SELECT
         JSON_VALUE(data, '$.id') as id,
         CAST(JSON_VALUE(data, '$.companyId') as INT64) as companyId,
         JSON_VALUE(data, '$.email') as email,

--- a/target_bigquery/utils.py
+++ b/target_bigquery/utils.py
@@ -61,7 +61,7 @@ class SchemaTranslator:
             "add_underscore_when_invalid": True
         }
         self.translated_schema = [
-            self._jsonschema_prop_to_bq_column(name, contents, fix_columns)
+            self._jsonschema_prop_to_bq_column(name, contents, self.fix_columns)
             for name, contents in self.schema.get("properties", {}).items()
         ]
 
@@ -103,7 +103,7 @@ class SchemaTranslator:
         self, safe_name, schema_property, mode="NULLABLE"
     ) -> SchemaField:
         fields = [
-            self._jsonschema_prop_to_bq_column(col, t)
+            self._jsonschema_prop_to_bq_column(col, t, fix_columns=self.fix_columns)
             for col, t in schema_property.get("properties", {}).items()
         ]
         return SchemaField(safe_name, "RECORD", mode, fields=fields)

--- a/target_bigquery/utils.py
+++ b/target_bigquery/utils.py
@@ -37,10 +37,10 @@ def safe_column_name(name: str, quotes: bool = False) -> str:
     name = re.sub(pattern, "_", name)
     if quotes:
         return "`{}`".format(name).lower()
-    # return "{}".format(name).lower()
-    if name[0].isdigit():
-        name = f"tmp_{name}"
-    return "`{}`".format(name)
+    return "{}".format(name).lower()
+    # if name[0].isdigit():
+    #     name = f"tmp_{name}"
+    # return "`{}`".format(name)
 
 
 # This class translates a JSON schema into a BigQuery schema.

--- a/target_bigquery/utils.py
+++ b/target_bigquery/utils.py
@@ -39,7 +39,7 @@ def safe_column_name(name: str, quotes: bool = False) -> str:
         return "`{}`".format(name).lower()
     # return "{}".format(name).lower()
     if name[0].isdigit():
-        name = f"_{name}"
+        name = f"tmp_{name}"
     return "`{}`".format(name)
 
 

--- a/target_bigquery/utils.py
+++ b/target_bigquery/utils.py
@@ -39,7 +39,7 @@ def safe_column_name(name: str, quotes: bool = False) -> str:
         return "`{}`".format(name).lower()
     # return "{}".format(name).lower()
     if name[0].isdigit():
-        return "`_{}`".format(name)
+        name = f"_{name}"
     return "`{}`".format(name)
 
 

--- a/target_bigquery/utils.py
+++ b/target_bigquery/utils.py
@@ -61,7 +61,6 @@ class SchemaTranslator:
         #     "add_underscore_when_invalid": True
         # }
         self.fix_columns = fix_columns
-        self.logger.info(fix_columns)
         self.translated_schema = [
             self._jsonschema_prop_to_bq_column(name, contents, self.fix_columns)
             for name, contents in self.schema.get("properties", {}).items()

--- a/target_bigquery/utils.py
+++ b/target_bigquery/utils.py
@@ -37,10 +37,10 @@ def safe_column_name(name: str, quotes: bool = False) -> str:
     name = re.sub(pattern, "_", name)
     if quotes:
         return "`{}`".format(name).lower()
-    return "{}".format(name).lower()
-    # if name[0].isdigit():
-    #     name = f"tmp_{name}"
-    # return "`{}`".format(name)
+    # return "{}".format(name).lower()
+    if name[0].isdigit():
+        return "_{}".format(name)
+    return "{}".format(name)
 
 
 # This class translates a JSON schema into a BigQuery schema.

--- a/target_bigquery/utils.py
+++ b/target_bigquery/utils.py
@@ -37,7 +37,10 @@ def safe_column_name(name: str, quotes: bool = False) -> str:
     name = re.sub(pattern, "_", name)
     if quotes:
         return "`{}`".format(name).lower()
-    return "{}".format(name).lower()
+    # return "{}".format(name).lower()
+    if name[0].isdigit():
+        return "`_{}`".format(name)
+    return "`{}`".format(name)
 
 
 # This class translates a JSON schema into a BigQuery schema.


### PR DESCRIPTION
This PR aims to add the fix_columns attribute to target-bigquery, allowing to specify changes to the target schema in order to comply with BigQuery guidelines.

In its current form, it supports:
- Lower
- Adding quotes
- Adding an underscore in front of columns that start with a number (to become compliant) 

In the future, it would be nice to replace with **kwargs