### PR TITLE
Enable authentication via ADC

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ tens of millions of rows with 3-4-500 key objects, its reasonably performant. It
 fall off given enough scale in the current state of the engineering at Google regarding BQ. Choose wisely.
 
 
-Sink names (you will most liekly be configuring this target via yaml or json so scroll on for the config table):
+Sink names (you will most likely be configuring this target via yaml or json so scroll on for the config table):
 
 ```python
 # batch job based
@@ -86,6 +86,7 @@ environment variable is set either in the terminal context or in the `.env` file
 
 ### Source Authentication and Authorization
 
+Authenticate via service account key file or Application Default Credentials (ADC)
 https://cloud.google.com/bigquery/docs/authentication
 
 ## Capabilities

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ license = "Apache 2.0"
 [tool.poetry.dependencies]
 python = "<3.11,>=3.8"
 requests = "^2.25.1"
-singer-sdk = "^0.14.0"
-google-cloud-bigquery = { version = ">=3.0.0", extras = ["bqstorage"] }
+singer-sdk = "^0.15.0"
+google-cloud-bigquery = { version = "^3.4.1", extras = ["bqstorage"] }
 orjson = "3.7.2"
 smart-open = { extras = ["gcs"], version = "^6.0.0" }
 tenacity = "^8.0.1"


### PR DESCRIPTION
If you have gcloud installed, you don't need to have Service Account Keys. Likewise, if you are running this on certain GCP services.

https://cloud.google.com/bigquery/docs/authentication/getting-started#application_default_credentials

Tested and works with all methods witch exception of the issue I noted here: https://github.com/z3z1ma/target-bigquery/issues/7