### PR TITLE
fix: Import `Sink` from `singer_sdk` package root

### DIFF
--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -14,8 +14,9 @@ import time
 import uuid
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Type, Union
 
+from singer_sdk import Sink
 from singer_sdk import typing as th
-from singer_sdk.target_base import Sink, Target
+from singer_sdk.target_base import Target
 
 from target_bigquery.batch_job import BigQueryBatchJobDenormalizedSink, BigQueryBatchJobSink
 from target_bigquery.core import BaseBigQuerySink, BaseWorker, BigQueryCredentials, ParType


### PR DESCRIPTION
Reported by users [in Slack](https://meltano.slack.com/archives/C01TCRBBJD7/p1680182634728169) after the SDK `0.22.1` release.