### PR TITLE
fix: View Creation fails with with reserved words in project name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "z3-target-bigquery"
-version = "0.6.3"
+version = "0.6.4"
 description = "z3-target-bigquery is a Singer target for BigQuery. It supports storage write, GCS, streaming, and batch load methods. Built with the Meltano SDK."
 authors = ["Alex Butler <butler.alex2010@gmail.com>"]
 keywords = ["ELT", "BigQuery"]


### PR DESCRIPTION
## tl;dr

Once a reserved word, such as `new`, exists as part of a view creation step (e.g., in the project or table name), the BQ query fails.

`column_name_transforms.quote` does not work to mitigate this (only quotes field names).

```
CREATE OR REPLACE VIEW new-XXX.XXX.repositories_view AS 
-- ...
google.api_core.exceptions.BadRequest: 400 Syntax error: Unexpected keyword NEW at [1:24] 
```

You can try this in the BQ consoled:

```sql
CREATE TABLE new-project.test -- ...
CREATE TABLE create.tablename -- implicit project
-- Syntax error: Unexpected keyword NEW at [1:14] 
```

## Steps to reproduce

```
python3 -m pip install --user pipx
pipx install meltano
meltano init
meltano add extractor tap-github
meltano add loader target-bigquery --variant z3z1ma
```

## Failure Scenarios

### Denormalized, Quoted

The following statement was meant to achieve the creation of a regular, flat table. That failed with a different error, but I create a separate ticket for that.

```yaml
# ...
plugins:
  extractors:
  - name: tap-github
    variant: meltanolabs
    pip_url: git+https://github.com/MeltanoLabs/tap-github.git
    config:
      start_date: '2023-01-01T00:00:00Z'
      searches:
      - name: Repos
        query: Meltano/*
    select: [repositories.*]
  loaders:
  - name: target-bigquery
    variant: z3z1ma
    pip_url: git+https://github.com/z3z1ma/target-bigquery.git
    config:
      project: new-XX
      location: XX
      dataset: XX
      credentials_path: $MELTANO_PROJECT_ROOT/client_secrets.json
      denormalized: false
      generate_view: true
      column_name_transforms:
        quote: true
```

Results in


```bash 
google.api_core.exceptions.BadRequest: 400 Syntax error: Unexpected keyword NEW at [1:24] 
```

Caused by the generated statement:

```sql 
CREATE OR REPLACE VIEW new-XXX.XXX.repositories_view AS 
-- ...
```

The word "new" only shows up in the project name as prefix, as outlined in the statement above, but causes the `CTAS` to fail. This is a legal project name, mind you.

### Default Settings

Works, but neither denormalizes, nor creates a view, making this data hard to use.

## Suggested Fix: View Creation

Since it's legal BQ SQL to escape the entire table identifier, we could do that in the SQL strings.

This PR makes this a function of the `BigQueryTable` model, which is cleaner, IMO. `name` or `__str__` should not return a quoted string.

**Caveats**: 
- Since this wasn't a function of the model before, it's hard for me to double check that I covered this in all cases. 
- The resulting view has a `Array cannot have a null element; error in writing field topics` error, but that could not be caused by this PR. That should probably be fixed, though. Probably also a separate ticket.

All UTs and ITs pass, though.

### Re-Test

| denormalized | generate view | quote | result                             |
| ------------ | ------------- | ----- | ---------------------------------- |
| FALSE        | TRUE          | FALSE | works                              |
| FALSE        | TRUE          | TRUE  | works                           
