### PR TITLE
Always pass the project ID to Google API clients

### DIFF
--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -578,9 +578,13 @@ def augmented_syspath(new_paths: Optional[Iterable[str]] = None):
 def bigquery_client_factory(creds: BigQueryCredentials) -> bigquery.Client:
     """Get a BigQuery client."""
     if creds.path:
-        return bigquery.Client.from_service_account_json(creds.path)
+        return bigquery.Client.from_service_account_json(creds.path,
+            project=creds.project
+        )
     elif creds.json:
-        return bigquery.Client.from_service_account_info(json.loads(creds.json))
+        return bigquery.Client.from_service_account_info(
+            json.loads(creds.json), project=creds.project
+        )
     return bigquery.Client(project=creds.project)
 
 
@@ -588,9 +592,11 @@ def bigquery_client_factory(creds: BigQueryCredentials) -> bigquery.Client:
 def gcs_client_factory(creds: BigQueryCredentials) -> storage.Client:
     """Get a GCS client."""
     if creds.path:
-        return storage.Client.from_service_account_json(creds.path)
+        return storage.Client.from_service_account_json(creds.path, project=creds.project)
     elif creds.json:
-        return storage.Client.from_service_account_info(json.loads(creds.json))
+        return storage.Client.from_service_account_info(
+            json.loads(creds.json), project=creds.project
+        )
     return storage.Client(project=creds.project)
 
 


### PR DESCRIPTION
The project ID configuration was being ignored when `credentials_path` or `credentials_json` was set. In these cases, the project ID was inferred from the credentials. However the inferred project might not be desired one, because the service account and the target BigQuery instance might belong to different projects.

My use case is the following: I have Meltano extracting data from a database in project A and sending it to BigQuery on project B. Meltano needs to run on project A because the source database is only accessible inside project A.