### PR TITLE
Wrap column name in quotes

### DIFF
--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -515,7 +515,7 @@ class BaseBigQuerySink(BatchSink):
                 f"target.`{f.name}` = source.`{f.name}`" for f in target.schema
             )
             insert_clause = (
-                f"INSERT ({', '.join(f.name for f in target.schema)}) "
+                f"INSERT ({', '.join(f'`{f.name}`' for f in target.schema)}) "
                 f"VALUES ({', '.join(f'source.`{f.name}`' for f in target.schema)})"
             )
             self.client.query(


### PR DESCRIPTION
This fixes an issue that occurs when a column name conflicts with a protected word in BigQuery. 