### PR TITLE
matf/stop-overwriting-state-on-empty-state

### DIFF
--- a/target_bigquery/target.py
+++ b/target_bigquery/target.py
@@ -526,5 +526,6 @@ class TargetBigQuery(Target):
         else:
             for sink in self._sinks_active.values():
                 sink.pre_state_hook()
-        self._write_state_message(state)
+        if state:
+            self._write_state_message(state)
         self._reset_max_record_age()


### PR DESCRIPTION
closes #52 

- if the state message is empty (that is, no state message was processed) then do not attempt to write the state as this can overwrite state in the event a tap produces no records (or no state message)