### PR TITLE
refactor(core): UUID suffix instead of Unix timestamp

### DIFF
--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -17,6 +17,7 @@ import shutil
 import sys
 import time
 import traceback
+import uuid
 from abc import ABC, abstractmethod
 
 try:
@@ -315,7 +316,7 @@ class BaseBigQuerySink(BatchSink):
             and self._is_upsert_candidate()
         ):
             self.merge_target = copy(self.table)
-            self.table = BigQueryTable(name=f"{self.table_name}__{int(time.time())}", **opts)
+            self.table = BigQueryTable(name=f"{self.table_name}__{uuid.uuid4()}", **opts)
             self.table.create_table(
                 self.client,
                 self.apply_transforms,
@@ -333,7 +334,7 @@ class BaseBigQuerySink(BatchSink):
             time.sleep(2.5)  # Wait for eventual consistency
         elif self._is_overwrite_candidate():
             self.overwrite_target = copy(self.table)
-            self.table = BigQueryTable(name=f"{self.table_name}__{int(time.time())}", **opts)
+            self.table = BigQueryTable(name=f"{self.table_name}__{uuid.uuid4()}", **opts)
             self.table.create_table(
                 self.client,
                 self.apply_transforms,


### PR DESCRIPTION
I'm attempting parallel writes to the same target BigQuery table from multiple source taps (using Meltano). When a Unix timestamp is used as a suffix for the intermediate table, there is a significant chance that concurrent processes produce the same name for it (i.e., if they happen to call `time.time()` within the same second). This results in a scenario in which the first process to finish loading records drops the table, and a latter process raises an exception - e.g.: `google.api_core.exceptions.BadRequest: 400 Not found: Table project:dataset.table_name__1699498892 was not found`.

I'm not sure if there was another motivation behind using the Unix timestamp as a suffix, but if it was purely for the sake of uniqueness, I'd like to recommend using a UUID v4 suffix instead, which is effectively guaranteed to be unique across concurrent processes.