### PR TITLE
Edge case for object properties with empty schemas

### DIFF
--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -806,9 +806,15 @@ class SchemaTranslator:
         self, name: str, schema_property: dict, mode: str = "NULLABLE"
     ) -> SchemaField:
         """Translate a JSON schema record into a BigQuery schema."""
+        properties = list(schema_property.get("properties", {}).items())
+        
+        # If no properties defined, store as JSON instead of RECORD
+        if len(properties) == 0:
+            return SchemaField(name, "JSON", mode)
+        
         fields = [
             self._jsonschema_property_to_bigquery_column(col, t)
-            for col, t in schema_property.get("properties", {}).items()
+            for col, t in properties
         ]
         return SchemaField(name, "RECORD", mode, fields=fields)
 


### PR DESCRIPTION
I ran into issues with properties that had the following type

```
{'items': {'type': 'object'}, 'type': ['null', 'array']}
```

because BQ was expecting a schema for the objects, but `target-bigquery` was generating an empty schema `RECORD` type. 

This PR changes that to a `JSON` type if there's nothing to base a schema on, in line with the general assumption that JSON is a good fallback.

Should break nothing, as hitting this edge case produces errors without this PR.