### PR TITLE
:wrench: add timeout also for batch jobs in load_table_from_uri

### DIFF
--- a/target_bigquery/batch_job.py
+++ b/target_bigquery/batch_job.py
@@ -63,6 +63,7 @@ class BatchJobWorker(BaseWorker):
                     BytesIO(job.data),
                     job.table,
                     num_retries=3,
+                    timeout=self.config.get("timeout", 600),
                     job_config=bigquery.LoadJobConfig(**job.config),
                 ).result()
             except Exception as exc:


### PR DESCRIPTION
## Description

This MR aims to fix the issue mentioned in [here](https://github.com/z3z1ma/target-bigquery/issues/89), where there seems to be some confusion between the docs and the implementation.

Summoning @z3z1ma 