### PR TITLE
:wrench: change logic to see if ds or table exists

### DIFF
--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -315,8 +315,7 @@ class BaseBigQuerySink(BatchSink):
         ):
             self.merge_target = copy(self.table)
             self.table = BigQueryTable(
-                name=f"{self.table_name}__{time.strftime('%Y%m%d%H%M%S')}__{uuid.uuid4()}", **opts
-            )
+                name=f"{self.table_name}__{time.strftime('%Y%m%d%H%M%S')}__{uuid.uuid4()}", **opts)
             self.table.create_table(
                 self.client,
                 self.apply_transforms,
@@ -335,8 +334,7 @@ class BaseBigQuerySink(BatchSink):
         elif self._is_overwrite_candidate():
             self.overwrite_target = copy(self.table)
             self.table = BigQueryTable(
-                name=f"{self.table_name}__{time.strftime('%Y%m%d%H%M%S')}__{uuid.uuid4()}", **opts
-            )
+                name=f"{self.table_name}__{time.strftime('%Y%m%d%H%M%S')}__{uuid.uuid4()}", **opts)
             self.table.create_table(
                 self.client,
                 self.apply_transforms,
@@ -812,7 +810,10 @@ class SchemaTranslator:
         if len(properties) == 0:
             return SchemaField(name, "JSON", mode)
 
-        fields = [self._jsonschema_property_to_bigquery_column(col, t) for col, t in properties]
+        fields = [
+                self._jsonschema_property_to_bigquery_column(col, t)
+                for col, t in properties
+                ]
         return SchemaField(name, "RECORD", mode, fields=fields)
 
     def _bigquery_field_to_projection(

--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -167,7 +167,7 @@ class BigQueryTable:
         table in a single method call. It is idempotent and will not create
         a new table if one already exists."""
         try:
-            self._dataset = client.get_dataset(self.as_dataset(**kwargs["dataset"]))
+            dataset = client.get_dataset(self.as_dataset(**kwargs["dataset"]))
         except NotFound:
             dataset = client.create_dataset(self.as_dataset(**kwargs["dataset"]))
         except (Conflict, Forbidden):
@@ -176,7 +176,7 @@ class BigQueryTable:
                     f"Location of existing dataset {dataset.dataset_id} ({dataset.location}) "
                     f"does not match specified location: {kwargs['dataset']['location']}"
                 )
-        else:
+        finally:
             self._dataset = dataset
         try:
             self._table = client.get_table(self.as_ref())

--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -39,7 +39,7 @@ from tempfile import TemporaryFile
 from textwrap import dedent, indent
 from typing import IO, TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
-from google.api_core.exceptions import Conflict, Forbidden
+from google.api_core.exceptions import Conflict, Forbidden, NotFound
 from google.cloud import bigquery, bigquery_storage_v1, storage
 from google.cloud.bigquery import SchemaField
 from google.cloud.bigquery.table import TimePartitioning, TimePartitioningType
@@ -166,7 +166,9 @@ class BigQueryTable:
         This is a convenience method that wraps the creation of a dataset and
         table in a single method call. It is idempotent and will not create
         a new table if one already exists."""
-        if not hasattr(self, "_dataset"):
+        try:
+            dataset = client.get_dataset(self.as_dataset(**kwargs["dataset"]))
+        except NotFound:
             try:
                 self._dataset = client.create_dataset(
                     self.as_dataset(**kwargs["dataset"]), exists_ok=False
@@ -180,7 +182,9 @@ class BigQueryTable:
                     )
                 else:
                     self._dataset = dataset
-        if not hasattr(self, "_table"):
+        try:
+            table = client.get_table(self.as_ref())
+        except NotFound:
             try:
                 self._table = client.create_table(
                     self.as_table(
@@ -317,7 +321,8 @@ class BaseBigQuerySink(BatchSink):
         ):
             self.merge_target = copy(self.table)
             self.table = BigQueryTable(
-                name=f"{self.table_name}__{time.strftime('%Y%m%d%H%M%S')}__{uuid.uuid4()}", **opts)
+                name=f"{self.table_name}__{time.strftime('%Y%m%d%H%M%S')}__{uuid.uuid4()}", **opts
+            )
             self.table.create_table(
                 self.client,
                 self.apply_transforms,
@@ -336,7 +341,8 @@ class BaseBigQuerySink(BatchSink):
         elif self._is_overwrite_candidate():
             self.overwrite_target = copy(self.table)
             self.table = BigQueryTable(
-                name=f"{self.table_name}__{time.strftime('%Y%m%d%H%M%S')}__{uuid.uuid4()}", **opts)
+                name=f"{self.table_name}__{time.strftime('%Y%m%d%H%M%S')}__{uuid.uuid4()}", **opts
+            )
             self.table.create_table(
                 self.client,
                 self.apply_transforms,
@@ -515,7 +521,7 @@ class BaseBigQuerySink(BatchSink):
                 tmp = f"{self.merge_target.name}__tmp"
                 dedupe_query = (
                     f"SELECT * FROM {self.table.get_escaped_name()} "
-                    f"QUALIFY ROW_NUMBER() OVER (PARTITION BY {', '.join(f'`{p}`' for p in self.key_properties)} " 
+                    f"QUALIFY ROW_NUMBER() OVER (PARTITION BY {', '.join(f'`{p}`' for p in self.key_properties)} "
                     f"ORDER BY COALESCE({', '.join(date_columns)}) DESC) = 1"
                 )
                 ctas_tmp = f"CREATE OR REPLACE TEMP TABLE `{tmp}` AS {dedupe_query}"
@@ -807,15 +813,12 @@ class SchemaTranslator:
     ) -> SchemaField:
         """Translate a JSON schema record into a BigQuery schema."""
         properties = list(schema_property.get("properties", {}).items())
-        
+
         # If no properties defined, store as JSON instead of RECORD
         if len(properties) == 0:
             return SchemaField(name, "JSON", mode)
-        
-        fields = [
-            self._jsonschema_property_to_bigquery_column(col, t)
-            for col, t in properties
-        ]
+
+        fields = [self._jsonschema_property_to_bigquery_column(col, t) for col, t in properties]
         return SchemaField(name, "RECORD", mode, fields=fields)
 
     def _bigquery_field_to_projection(
@@ -892,14 +895,18 @@ class SchemaTranslator:
         )
         v = _v.as_sql().rstrip(", \n")
         return (" " * depth * 2) + indent(
-            dedent(f"""
+            dedent(
+                f"""
         ARRAY(
             SELECT {v}
             FROM UNNEST(
                 JSON_QUERY_ARRAY({base}, '{path}.{field.name}')
             ) AS {field.name}__rows
             WHERE {_v.projection} IS NOT NULL
-        """ + (" " * depth * 2) + f") AS {field.name},\n").lstrip(),
+        """
+                + (" " * depth * 2)
+                + f") AS {field.name},\n"
+            ).lstrip(),
             " " * depth * 2,
         )
 

--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -169,16 +169,15 @@ class BigQueryTable:
         try:
             self._dataset = client.get_dataset(self.as_dataset(**kwargs["dataset"]))
         except NotFound:
-            try:
-                dataset = client.create_dataset(self.as_dataset(**kwargs["dataset"]))
-            except (Conflict, Forbidden):
-                if dataset.location != kwargs["dataset"]["location"]:
-                    raise Exception(
-                        f"Location of existing dataset {dataset.dataset_id} ({dataset.location}) "
-                        f"does not match specified location: {kwargs['dataset']['location']}"
-                    )
-                else:
-                    self._dataset = dataset
+            dataset = client.create_dataset(self.as_dataset(**kwargs["dataset"]))
+        except (Conflict, Forbidden):
+            if dataset.location != kwargs["dataset"]["location"]:
+                raise Exception(
+                    f"Location of existing dataset {dataset.dataset_id} ({dataset.location}) "
+                    f"does not match specified location: {kwargs['dataset']['location']}"
+                )
+        else:
+            self._dataset = dataset
         try:
             self._table = client.get_table(self.as_ref())
         except NotFound:


### PR DESCRIPTION
## Description

The goal of this MR is to tackle the issue mentioned [here](https://github.com/z3z1ma/target-bigquery/issues/83). The explanation is pretty much there.

## Implementation

Right now to check if something exists the code tries to create the dataset with the parameter `exists_ok`, which in the internal bigquery library it just avoids raising an Exception as documented [here](https://cloud.google.com/python/docs/reference/bigquery/latest/google.cloud.bigquery.client.Client#google_cloud_bigquery_client_Client_create_dataset).

The issue is that those calls are still created on the API and then handled in code, and your logs are going to be flooded with errors in your bigquery API.

With this MR the aim is to add an extra call to get the resources (dataset or table) and handle the `NotFound` exception itself. There is a potential cons that is making an additional call to the API to check if the resource actually exists.

Summoning @z3z1ma  @blancaruano