### PR TITLE
added fix for transform_column_name and changed code to pass test

### DIFF
--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -751,8 +751,8 @@ class SchemaTranslator:
                 )
 
         return (
-            f"CREATE OR REPLACE VIEW {table_name.get_escaped_name('_view')} AS \nSELECT"
-            f" \n{projection} FROM {table_name.get_escaped_name()}"
+            f"CREATE OR REPLACE VIEW {table_name.get_escaped_name('_view')} AS\nSELECT"
+            f"\n{projection} FROM {table_name.get_escaped_name()}"
         )
 
     def _jsonschema_property_to_bigquery_column(
@@ -1084,8 +1084,12 @@ def transform_column_name(
     add_underscore_when_invalid: bool = False,
     snake_case: bool = False,
     replace_period_with_underscore: bool = False,
+    **kwargs
 ) -> str:
-    """Transform a column name to a valid BigQuery column name."""
+    """Transform a column name to a valid BigQuery column name.
+    kwargs is here to handle unspecified column tranforms, this can become an issue if config is added in main
+    branch but code is versioned to run on an old commit.
+    """
     if snake_case and not lower:
         lower = True
     was_quoted = name.startswith("`") and name.endswith("`")


### PR DESCRIPTION
transform_column_name gets called with unpacked arguments. This means that you can get errors like this 
`TypeError: transform_column_name() got an unexpected keyword argument 'replace_period_with_underscore'`
if you run a version of the target that doesn't have that `column_name_transforms`. 

I assume the reason is that meltano does some weird logic where it pulls the config options from the latest version of the target but allows for previous version of the code.  

This PR should fix it and also solve the problems with the tests that fails ( It worked when I ran the tests locally) 
 