### PR TITLE
fix: Apply transforms before resolving schema changes

### DIFF
--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -589,7 +589,7 @@ class Denormalized:
     )
     def update_schema(self: BaseBigQuerySink) -> None:  # type: ignore
         """Update the target schema."""
-        table = self.table.as_table()
+        table = self.table.as_table(self.apply_transforms)
         current_schema = table.schema[:]
         mut_schema = table.schema[:]
         for expected_field in self.table.get_resolved_schema(self.apply_transforms):

--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -151,7 +151,6 @@ class BigQueryTable:
         """Returns a DatasetReference for this table."""
         return bigquery.DatasetReference(self.project, self.dataset)
 
-    @cache
     def as_table(self, apply_transforms: bool = False, **kwargs) -> bigquery.Table:
         """Returns a Table instance for this table."""
         if hasattr(self, "_table"):

--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -154,6 +154,9 @@ class BigQueryTable:
     @cache
     def as_table(self, apply_transforms: bool = False, **kwargs) -> bigquery.Table:
         """Returns a Table instance for this table."""
+        if hasattr(self, "_table"):
+            return self._table
+
         table = bigquery.Table(
             self.as_ref(),
             schema=self.get_resolved_schema(apply_transforms),


### PR DESCRIPTION
Given `denormalization` and `column_name_transforms.snake_case` enabled, this change
- resolves `Field already exists in schema` error from the BigQuery API
- prevents two columns from being created for the same property, i.e. `StartDate` and `start_date` on table creation

---

Closes #66