### PR TITLE
fix: Append duplicate count suffix to schema fields with the same name

### DIFF
--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -719,6 +719,15 @@ class SchemaTranslator:
                 )
                 for name, contents in self.schema.get("properties", {}).items()
             ]
+
+        field_name_count = {}
+        for f in self._translated_schema_transformed:
+            field_name = f.name
+            count = field_name_count.get(field_name, 0)
+            if count:
+                f._properties["name"] += f"_{count}"
+            field_name_count[field_name] = count + 1
+
         return self._translated_schema_transformed
 
     def translate_record(self, record: dict) -> dict:


### PR DESCRIPTION
Given the following example (from #120) with `column_name_transforms.snake_case` enabled -- now:

1. `StartDate` -> `start_date`
1. `Start_Date` -> `start_date_1`

No reason to see why this suffix couldn't become a config option in the future, if required.

---

Closes #120