### PR TITLE
fix: Apply transforms for job-based sinks

### DIFF
--- a/target_bigquery/batch_job.py
+++ b/target_bigquery/batch_job.py
@@ -101,7 +101,7 @@ class BigQueryBatchJobSink(BaseBigQuerySink):
     @property
     def job_config(self) -> Dict[str, Any]:
         return {
-            "schema": self.table.get_resolved_schema(),
+            "schema": self.table.get_resolved_schema(self.apply_transforms),
             "source_format": bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
             "write_disposition": bigquery.WriteDisposition.WRITE_APPEND,
         }
@@ -141,7 +141,7 @@ class BigQueryBatchJobDenormalizedSink(Denormalized, BigQueryBatchJobSink):
     @property
     def job_config(self) -> Dict[str, Any]:
         return {
-            "schema": self.table.get_resolved_schema(),
+            "schema": self.table.get_resolved_schema(self.apply_transforms),
             "source_format": bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
             "write_disposition": bigquery.WriteDisposition.WRITE_APPEND,
             "schema_update_options": [

--- a/target_bigquery/gcs_stage.py
+++ b/target_bigquery/gcs_stage.py
@@ -161,7 +161,7 @@ class BigQueryGcsStagingSink(BaseBigQuerySink):
     @property
     def job_config(self) -> Dict[str, Any]:
         return {
-            "schema": self.table.get_resolved_schema(),
+            "schema": self.table.get_resolved_schema(self.apply_transforms),
             "source_format": bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
             "write_disposition": bigquery.WriteDisposition.WRITE_APPEND,
         }
@@ -256,7 +256,7 @@ class BigQueryGcsStagingDenormalizedSink(Denormalized, BigQueryGcsStagingSink):
     @property
     def job_config(self) -> Dict[str, Any]:
         return {
-            "schema": self.table.get_resolved_schema(),
+            "schema": self.table.get_resolved_schema(self.apply_transforms),
             "source_format": bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
             "write_disposition": bigquery.WriteDisposition.WRITE_APPEND,
             "schema_update_options": [


### PR DESCRIPTION
Ensure schema matches target table when using `denormalized: true` and `upsert: true`, preventing `NULL` data for misaligned columns.