### PR TITLE
fix: Finalise record count metrics

### DIFF
--- a/target_bigquery/core.py
+++ b/target_bigquery/core.py
@@ -574,6 +574,7 @@ class BaseBigQuerySink(BatchSink):
             self.table = cast(BigQueryTable, self.merge_target)
             self.overwrite_target = None
 
+        super().clean_up()
 
 class Denormalized:
     """This class provides common overrides for denormalized sinks and should be subclassed


### PR DESCRIPTION
This target's base sink class currently overrides `clean_up` but doesn't not call the super implementation, which is responsilbe for finalising the record counter.